### PR TITLE
Deprecated: Event dispatcher swapped params with new versions

### DIFF
--- a/src/Mcfedr/QueueManagerBundle/Runner/JobExecutor.php
+++ b/src/Mcfedr/QueueManagerBundle/Runner/JobExecutor.php
@@ -21,6 +21,8 @@ use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 
 class JobExecutor
 {
@@ -58,18 +60,14 @@ class JobExecutor
 
     public function startBatch(JobBatch $batch): void
     {
-        if ($this->eventDispatcher) {
-            $this->eventDispatcher->dispatch(self::JOB_BATCH_START_EVENT, new StartJobBatchEvent($batch->getJobs()));
-        }
+        $this->dispatch(self::JOB_BATCH_START_EVENT, new StartJobBatchEvent($batch->getJobs()));
         $this->batchStarted = true;
     }
 
     public function finishBatch(JobBatch $batch): void
     {
         $this->batchStarted = false;
-        if ($this->eventDispatcher) {
-            $this->eventDispatcher->dispatch(self::JOB_BATCH_FINISHED_EVENT, new FinishedJobBatchEvent($batch->getOks(), $batch->getRetries(), $batch->getFails(), $batch->getJobs()));
-        }
+        $this->dispatch(self::JOB_BATCH_FINISHED_EVENT, new FinishedJobBatchEvent($batch->getOks(), $batch->getRetries(), $batch->getFails(), $batch->getJobs()));
     }
 
     /**
@@ -101,9 +99,7 @@ class JobExecutor
                 throw new InvalidWorkerException("The worker {$job->getName()} is not an instance of ".Worker::class);
             }
             $internal = $worker instanceof InternalWorker;
-            if ($this->eventDispatcher) {
-                $this->eventDispatcher->dispatch(self::JOB_START_EVENT, new StartJobEvent($job, $internal));
-            }
+            $this->dispatch(self::JOB_START_EVENT, new StartJobEvent($job, $internal));
             $worker->execute($job->getArguments());
         } catch (NotFoundExceptionInterface $e) {
             $unrecoverable = new UnrecoverableJobException("Missing worker {$job->getName()}", 0, $e);
@@ -147,9 +143,7 @@ class JobExecutor
                 'arguments' => $job->getArguments(),
             ]);
         }
-        if ($this->eventDispatcher) {
-            $this->eventDispatcher->dispatch(self::JOB_FINISHED_EVENT, new FinishedJobEvent($job, $internal));
-        }
+        $this->dispatch(self::JOB_FINISHED_EVENT, new FinishedJobEvent($job, $internal));
         if ($this->triggerBatchEvents) {
             $this->finishBatch(new JobBatch([], [$job]));
         }
@@ -173,14 +167,29 @@ class JobExecutor
             }
             $this->logger->error('Job failed.', $context);
         }
-        if ($this->eventDispatcher) {
-            $this->eventDispatcher->dispatch(self::JOB_FAILED_EVENT, new FailedJobEvent($job, $exception, $internal));
-        }
+        $this->dispatch(self::JOB_FAILED_EVENT, new FailedJobEvent($job, $exception, $internal));
         if ($this->triggerBatchEvents) {
             $batch = new JobBatch([$job]);
             $batch->next();
             $batch->result($exception);
             $this->finishBatch($batch);
+        }
+    }
+
+    /**
+     * Provide a BC way to dispatch events.
+     *
+     * @param string $eventName
+     * @param \Event $event
+     */
+    private function dispatch(string $eventName, Event\Event $event): void
+    {
+        if ($this->eventDispatcher) {
+            if ('42' !== Kernel::MAJOR_VERSION.Kernel::MINOR_VERSION && class_exists(ContractEvent::class)) {
+                $this->eventDispatcher->dispatch($event, $eventName);
+            } else {
+                $this->eventDispatcher->dispatch($eventName, $event);
+            }
         }
     }
 }


### PR DESCRIPTION
[2019-07-05 20:29:09] php.INFO: User Deprecated: Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead. {"exception":"[object] (ErrorException(code: 0): User Deprecated: Calling the \"Symfony\\Component\\EventDispatcher\\EventDispatcherInterface::dispatch()\" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead. at /srv/project/vendor/symfony/event-dispatcher/EventDispatcher.php:58)"} []