### PR TITLE
added support of carbon 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=8.0",
         "ext-json": "*",
         "symfony/framework-bundle": "^5.0|^6.0|^7.0",
-        "nesbot/carbon": "^1|^2",
+        "nesbot/carbon": "^1|^2|^3",
         "ramsey/uuid": "^3.7|^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
Carbon 2 has dependency until symfony 6 only. So we need add  carbon 3 to support symfony 7